### PR TITLE
fix: handle error in AddMethodForm catch block

### DIFF
--- a/app/manage/methods/AddMethodForm.tsx
+++ b/app/manage/methods/AddMethodForm.tsx
@@ -45,7 +45,7 @@ export function AddMethodForm({ onSuccess }: AddMethodFormProps = {}) {
           {error}
         </Alert>
       )}
-      
+
       <Stack spacing={2}>
         <Input
           control={control}
@@ -53,17 +53,17 @@ export function AddMethodForm({ onSuccess }: AddMethodFormProps = {}) {
           label="Method Name"
           rules={{ required: 'Method name is required' }}
         />
-        
+
         <Button
           type="submit"
           variant="contained"
           startIcon={<LocalCafe />}
           disabled={isSubmitting}
           fullWidth
-          sx={{ 
+          sx={{
             mt: 2,
-            bgcolor: '#8B4513', 
-            '&:hover': { bgcolor: '#6B3410' }
+            bgcolor: '#8B4513',
+            '&:hover': { bgcolor: '#6B3410' },
           }}
         >
           {isSubmitting ? 'Adding Method...' : 'Add Method'}

--- a/app/manage/methods/AddMethodForm.tsx
+++ b/app/manage/methods/AddMethodForm.tsx
@@ -15,9 +15,11 @@ export function AddMethodForm({ onSuccess }: AddMethodFormProps = {}) {
   const { control, handleSubmit, reset } = useForm<MethodFormData>()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [success, setSuccess] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
   const onSubmit = async (data: MethodFormData) => {
     setIsSubmitting(true)
+    setError(null)
     try {
       await addMethod(data)
       reset()
@@ -25,6 +27,7 @@ export function AddMethodForm({ onSuccess }: AddMethodFormProps = {}) {
       setTimeout(() => setSuccess(false), 3000)
       onSuccess?.()
     } catch {
+      setError('Failed to add method')
     } finally {
       setIsSubmitting(false)
     }
@@ -35,6 +38,11 @@ export function AddMethodForm({ onSuccess }: AddMethodFormProps = {}) {
       {success && (
         <Alert severity="success" sx={{ mb: 2 }}>
           ✅ Method added successfully!
+        </Alert>
+      )}
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
         </Alert>
       )}
       


### PR DESCRIPTION
This pull request was created by @kiro-agent on behalf of @orriborri :ghost:

Comment with **/kiro fix** to address specific feedback or **/kiro all** to address everything.
<sub>[Learn about Kiro Web](https://kiro.dev/web/)</sub>

---
## Summary

Fixes the empty block statement reported in #107 (JS-0009).

### Changes

- Added `error` state to `AddMethodForm` component
- Added error handling in the previously-empty `catch` block that sets a user-friendly error message
- Added error `Alert` component to display the error to users
- Clear error state at the start of each form submission

This follows the same error handling pattern used by `AddGrinderForm.tsx` in the project.

### Testing

- TypeScript compilation passes (`pnpm tsc --noEmit`)
- ESLint passes (`pnpm next lint`)

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Method submission forms now display error messages when an error occurs during submission, providing users with clear feedback on what went wrong and enabling them to troubleshoot and retry effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->